### PR TITLE
Revert "🚈  deps: update Gbox to version 0.0.8 with new SHA256"

### DIFF
--- a/gbox.rb
+++ b/gbox.rb
@@ -7,7 +7,7 @@ class Gbox < Formula
   homepage "https://github.com/babelcloud/gru-sandbox"
 
   # Version definition
-  GBOX_VERSION = "0.0.8"
+  GBOX_VERSION = "0.0.7"
   version ENV["HOMEBREW_GBOX_VERSION"] || GBOX_VERSION
 
   # Base URL for downloads
@@ -15,10 +15,10 @@ class Gbox < Formula
   url ENV["HOMEBREW_GBOX_URL"] || "#{base_url}/gbox-#{OS.mac? ? "darwin" : "linux"}-#{Hardware::CPU.arm? ? "arm64" : "amd64"}-#{version}.tar.gz"
 
   # SHA256 definitions for different architectures
-  DARWIN_ARM64_SHA256 = "85756844e7b578345286c545edd08094c06c5fe18abc02a09b5fabfe7f5c3900"
-  DARWIN_AMD64_SHA256 = "2757185ba01fbc6e27e90e3b77118822dcc812c0f07c88045589a9ddf1cd6fcc"
-  LINUX_ARM64_SHA256  = "211c389d8dae7c1a4ecb13a0f35eede3c1a54dbe2b5cd88e25fadd1eaeb02220"
-  LINUX_AMD64_SHA256  = "9a1c62f2d1d54a5b9d590dd5f267445b179a5ecaa16ecc36ad541943abd362a3"
+  DARWIN_ARM64_SHA256 = "1a68e89ea04cd3181b474db8256b50f540b83d6946283f535febbc68cee25b85"
+  DARWIN_AMD64_SHA256 = "3d403c4e77826d828f5fc1d4e5cf80e8336d7dc6fad3d8d036186265928cf5ac"
+  LINUX_ARM64_SHA256  = "4ee60fc941f83091788921096477099bab007332217b8a462c6bf61bc17cae28"
+  LINUX_AMD64_SHA256  = "bc7926c7b4df03af299f84e5ec34c9021bc82829cbed9c4dfbefa85f43ac07b0"
 
   def self.get_sha256(url)
     return default_sha256 unless ENV["HOMEBREW_GBOX_URL"]


### PR DESCRIPTION
Reverts babelcloud/homebrew-gru#9